### PR TITLE
fixed import and Template args

### DIFF
--- a/src/environmentbase/environmentbase.py
+++ b/src/environmentbase/environmentbase.py
@@ -1,7 +1,7 @@
 import os
 import os.path
 from troposphere import Select, Ref, Parameter, FindInMap, Output, Base64, Join, GetAtt
-import Template
+from .template import Template
 import troposphere.iam as iam
 import troposphere.ec2 as ec2
 import troposphere.autoscaling as autoscaling
@@ -28,7 +28,7 @@ class EnvironmentBase(object):
         self.globals                    = arg_dict.get('global', {})
         self.template_args              = arg_dict.get('template', {})
 
-        self.template                   = Template()
+        self.template                   = Template('default_template')
         self.template.description       = self.template_args.get('description', 'No Description Specified')
 
         self.manual_parameter_bindings  = {}


### PR DESCRIPTION
Fixed a couple of issues I encountered when trying to run `environmentbase -h` but got stuck on 

```
  File "/Users/gabrielreyla/dev/cloudformation-environmentbase/src/environmentbase/environmentbase.py", line 236, in add_ami_mapping
    with open(ami_map_file_path, 'r') as json_file:
IOError: [Errno 2] No such file or directory: u'ami_cache.json'
```

@patrickmcclory for your review 
