### PR TITLE
Allows NAT role customization.

### DIFF
--- a/src/environmentbase/networkbase.py
+++ b/src/environmentbase/networkbase.py
@@ -176,7 +176,7 @@ class NetworkBase(EnvironmentBase):
             nat_instance_type = self.config['nat']['instance_type']
             nat_enable_ntp = self.config['nat']['enable_ntp']
             extra_user_data = self.config['nat'].get('extra_user_data')
-            self.template.merge(ha_nat.HaNat(
+            self.template.merge(self.create_nat(
               index,
               nat_instance_type,
               nat_enable_ntp,
@@ -188,6 +188,18 @@ class NetworkBase(EnvironmentBase):
         Override to allow subclasses to create VPGs and similar components during network creation
         """
         pass
+
+    def create_nat(self, index, nat_instance_type, enable_ntp, name, extra_user_data=None):
+        """
+        Override to customize your NAT instance. The returned object must be a
+        subclass of ha_nat.HaNat.
+        """
+        return ha_nat.HaNat(
+            index,
+            nat_instance_type,
+            nat_enable_ntp,
+            name=name,
+            extra_user_data=extra_user_data)
 
     def add_network_cidr_mapping(self,
                                  network_config):

--- a/src/environmentbase/patterns/ha_nat.py
+++ b/src/environmentbase/patterns/ha_nat.py
@@ -71,6 +71,13 @@ class HaNat(Template):
             CidrIp='0.0.0.0/0'
         ))
 
+    def get_extra_policy_statements(self):
+        '''
+        Return policy statements for additional permissions you want your NAT
+        to have.
+        '''
+        return []
+
     def add_nat_instance_profile(self):
         '''
         Create the NAT role and instance profile
@@ -110,7 +117,7 @@ class HaNat(Template):
                         "Effect": "Allow",
                         "Action": policy_actions,
                         "Resource": "*"
-                    }]
+                    }] + self.get_extra_policy_statements()
                 }
             )]
         ))

--- a/src/tests/test_environmentbase.py
+++ b/src/tests/test_environmentbase.py
@@ -8,6 +8,8 @@ import sys
 import copy
 from tempfile import mkdtemp
 from environmentbase import cli, resources as res, environmentbase as eb
+from environmentbase import networkbase
+import environmentbase.patterns.ha_nat
 from troposphere import ec2
 
 # commentjson is optional, parsing invalid json throws commonjson.JSONLibraryException
@@ -388,6 +390,60 @@ nat:
             self.assertTrue('ec2instance' in template['Resources'])
 
             # print json.dumps(template, indent=4)
+
+    def test_nat_role_customization(self):
+        """ Example of out to subclass the Controller to provide additional resources """
+        class MyNat(environmentbase.patterns.ha_nat.HaNat):
+            def get_extra_policy_statements(self):
+              return [{
+                  "Effect": "Allow",
+                  "Action": ["DummyAction"],
+                  "Resource": "*"
+              }]
+
+        class MyController(networkbase.NetworkBase):
+            def __init__(self, view):
+                # Run parent initializer
+                networkbase.NetworkBase.__init__(self, view)
+
+            def create_nat(self, index, nat_instance_type, enable_ntp, name, extra_user_data=None):
+                return MyNat(index, nat_instance_type, enable_ntp, name, extra_user_data)
+
+            def create_action(self):
+                self.initialize_template()
+                self.construct_network()
+
+                # This triggers serialization of the template and any child stacks
+                self.write_template_to_file()
+
+        # Initialize the the controller with faked 'create' CLI parameter
+        with patch.object(sys, 'argv', ['environmentbase', 'init']):
+            ctrlr = MyController(cli.CLI(quiet=True))
+            ctrlr.load_config()
+            ctrlr.create_action()
+
+            # Load the generated output template
+            template_path = ctrlr._ensure_template_dir_exists()
+            with open(template_path, 'r') as f:
+                template = json.load(f)
+
+            # Verify that the ec2 instance is in the output
+            self.assertIn('Nat0Role', template['Resources'])
+            self.assertIn('Properties', template['Resources']['Nat0Role'])
+            self.assertIn('Policies', template['Resources']['Nat0Role']['Properties'])
+            self.assertEqual(len(template['Resources']['Nat0Role']['Properties']['Policies']), 1)
+            self.assertIn(
+              'PolicyDocument',
+              template['Resources']['Nat0Role']['Properties']['Policies'][0])
+            self.assertIn(
+              'Statement',
+              template['Resources']['Nat0Role']['Properties']['Policies'][0]['PolicyDocument'])
+            self.assertEqual(
+              len(template['Resources']['Nat0Role']['Properties']['Policies'][0]['PolicyDocument']['Statement']),
+              2)
+            self.assertEqual(
+              template['Resources']['Nat0Role']['Properties']['Policies'][0]['PolicyDocument']['Statement'][1]['Action'],
+              ['DummyAction'])
 
 
     # Cloudformation doesn't currently support a dry run, so this test would create a live stack

--- a/src/tests/test_environmentbase.py
+++ b/src/tests/test_environmentbase.py
@@ -432,18 +432,11 @@ nat:
             self.assertIn('Properties', template['Resources']['Nat0Role'])
             self.assertIn('Policies', template['Resources']['Nat0Role']['Properties'])
             self.assertEqual(len(template['Resources']['Nat0Role']['Properties']['Policies']), 1)
-            self.assertIn(
-              'PolicyDocument',
-              template['Resources']['Nat0Role']['Properties']['Policies'][0])
-            self.assertIn(
-              'Statement',
-              template['Resources']['Nat0Role']['Properties']['Policies'][0]['PolicyDocument'])
-            self.assertEqual(
-              len(template['Resources']['Nat0Role']['Properties']['Policies'][0]['PolicyDocument']['Statement']),
-              2)
-            self.assertEqual(
-              template['Resources']['Nat0Role']['Properties']['Policies'][0]['PolicyDocument']['Statement'][1]['Action'],
-              ['DummyAction'])
+            policy = template['Resources']['Nat0Role']['Properties']['Policies'][0];
+            self.assertIn('PolicyDocument', policy)
+            self.assertIn('Statement', policy['PolicyDocument'])
+            self.assertEqual(len(policy['PolicyDocument']['Statement']), 2)
+            self.assertEqual(policy['PolicyDocument']['Statement'][1]['Action'], ['DummyAction'])
 
 
     # Cloudformation doesn't currently support a dry run, so this test would create a live stack


### PR DESCRIPTION
@sesas @gimballock This allows the client to subclass the `HaNat` class and customize its role permissions, which is needed when you take advantage of its capability for extra initialization from #11.
