### PR TITLE
Exports bastion security group

### DIFF
--- a/src/environmentbase/patterns/bastion.py
+++ b/src/environmentbase/patterns/bastion.py
@@ -64,6 +64,11 @@ class Bastion(Template):
             Value=GetAtt(bastion_elb, 'DNSName')
         ))
 
+        self.add_output(Output(
+            'BastionSecurityGroupId',
+            Value=Ref(security_groups['bastion'])
+        ))
+
     @staticmethod
     def get_factory_defaults():
         return {"bastion": {


### PR DESCRIPTION
@sesas @gimballock A security group ID can be useful for restricting SSH traffic to the web hosts.
