### PR TITLE
Enable autowiring of child outputs

### DIFF
--- a/src/environmentbase/data/config.json
+++ b/src/environmentbase/data/config.json
@@ -38,30 +38,5 @@
         "region_name": "us-west-2",
         "aws_access_key_id": null,
         "aws_secret_access_key": null
-    },
-    "network": {
-        "network_cidr_base": "10.0.0.0",
-        "network_cidr_size": "16",
-        "az_count": 3,
-        "subnet_types": [
-            "public",
-            "private"
-        ],
-        "subnet_config": [
-            {
-                "type": "public",
-                "size": "18",
-                "name": "public"
-            },
-            {
-                "type": "private",
-                "size": "22",
-                "name": "private"
-            },
-        ],
-    },
-    "nat": {
-        "instance_type": "t2.micro",
-        "enable_ntp": false
     }
 }

--- a/src/environmentbase/data/config_schema.json
+++ b/src/environmentbase/data/config_schema.json
@@ -34,17 +34,6 @@
         # Name of the bucket to use for storing log files
         "s3_bucket": "basestring"
     },
-    "network": {
-        "az_count": "int",
-        "subnet_types": "list",
-        "subnet_config": "list",
-        "network_cidr_base": "basestring",
-        "network_cidr_size": "basestring"
-    },
-    "nat": {
-        "instance_type": "basestring",
-        "enable_ntp": "bool"
-    },
     "boto": {
         "region_name": "basestring"
     }

--- a/src/environmentbase/environmentbase.py
+++ b/src/environmentbase/environmentbase.py
@@ -73,6 +73,7 @@ class EnvironmentBase(object):
         # self.env_config = env_config
         for config_handler in env_config.config_handlers:
             self._add_config_handler(config_handler)
+        self.add_config_hook()
 
         # Load the user interface
         self.view = view if view else cli.CLI()
@@ -88,6 +89,14 @@ class EnvironmentBase(object):
         """
         Override in your subclass for custom resource creation.  Called after config is loaded and template is
         initialized.  After the hook completes the templates are serialized and written to file and uploaded to S3.
+        """
+        pass
+
+    def add_config_hook(self):
+        """
+        Override in your subclass for adding custom config handlers.  
+        Called after the other config handlers have been added.  
+        After the hook completes the view is loaded and started.
         """
         pass
 

--- a/src/environmentbase/environmentbase.py
+++ b/src/environmentbase/environmentbase.py
@@ -175,7 +175,7 @@ class EnvironmentBase(object):
         raw_json = template.to_template_json()
 
         # Recursively iterate through each child template to serialize it and process its children
-        for child, _, _ in template._child_templates:
+        for child, _, _, _, _ in template._child_templates:
             EnvironmentBase.serialize_templates_helper(
                 template=child,
                 s3_client=s3_client,

--- a/src/environmentbase/networkbase.py
+++ b/src/environmentbase/networkbase.py
@@ -10,6 +10,9 @@ class NetworkBase(EnvironmentBase):
     for a common deployment within AWS. This is intended to be the 'base' stack for deploying child stacks
     """
 
+    def add_config_hook(self):
+        self._add_config_handler(BaseNetwork)
+
     def create_hook(self):
         super(NetworkBase, self).create_hook()
 

--- a/src/environmentbase/networkbase.py
+++ b/src/environmentbase/networkbase.py
@@ -11,6 +11,7 @@ class NetworkBase(EnvironmentBase):
     """
 
     def add_config_hook(self):
+        super(NetworkBase, self).add_config_hook()
         self._add_config_handler(BaseNetwork)
 
     def create_hook(self):

--- a/src/environmentbase/networkbase.py
+++ b/src/environmentbase/networkbase.py
@@ -25,8 +25,6 @@ class NetworkBase(EnvironmentBase):
         base_network_template = BaseNetwork('BaseNetwork', network_config, region_name, nat_config)
         self.add_child_template(base_network_template)
 
-        self.template.add_child_outputs_to_parameter_binding(base_network_template, propagate_up=True)
-
         self.template._subnets = base_network_template._subnets.copy()
         self.template._vpc_id = GetAtt(base_network_template.name, 'Outputs.vpcId')
 

--- a/src/environmentbase/patterns/base_network.py
+++ b/src/environmentbase/patterns/base_network.py
@@ -12,6 +12,60 @@ from environmentbase.utility import tropo_to_string
 
 
 class BaseNetwork(Template):
+    DEFAULT_CONFIG = {
+        "network": {
+            "network_cidr_base": "10.0.0.0",
+            "network_cidr_size": "16",
+            "az_count": 3,
+            "subnet_types": [
+                "public",
+                "private"
+            ],
+            "subnet_config": [
+                {
+                    "type": "public",
+                    "size": "18",
+                    "name": "public"
+                },
+                {
+                    "type": "private",
+                    "size": "22",
+                    "name": "private"
+                },
+            ],
+        },
+        "nat": {
+            "instance_type": "t2.micro",
+            "enable_ntp": False
+        }
+    }
+
+    CONFIG_SCHEMA = {
+        "network": {
+            "az_count": "int",
+            "subnet_types": "list",
+            "subnet_config": "list",
+            "network_cidr_base": "basestring",
+            "network_cidr_size": "basestring"
+        },
+        "nat": {
+            "instance_type": "basestring",
+            "enable_ntp": "bool"
+        }
+    }
+
+    # When no config.json file exists a new one is created using the 'factory default' file.  This function
+    # augments the factory default before it is written to file with the config values required
+    @staticmethod
+    def get_factory_defaults():
+        return BaseNetwork.DEFAULT_CONFIG
+
+    # When the user request to 'create' a new BaseNetwork template the config.json file is read in. This file is checked to
+    # ensure all required values are present. Because BaseNetwork has additional requirements beyond that of
+    # EnvironmentBase this function is used to add additional validation checks.
+    @staticmethod
+    def get_config_schema():
+        return BaseNetwork.CONFIG_SCHEMA
 
     def __init__(self, template_name, network_config, region_name, nat_config):
         super(BaseNetwork, self).__init__(template_name)


### PR DESCRIPTION
Enabled autowiring of child's output by default.  The option can be disabled when adding the child template to the root template. 

@gimballock @odandia 
